### PR TITLE
docker-compose導入

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM jelastic/maven:3.9.5-openjdk-21
+WORKDIR /app
+COPY pom.xml ./
+COPY src ./src/
+
+CMD ["mvn", "spring-boot:run"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,27 @@ java -jar target/demo-0.0.1-SNAPSHOT.jar
 jar tvf target/demo-0.0.1-SNAPSHOT.jar.original
 ```
 
+# docker構築
+## dockerイメージ構築
+```
+docker compose build --no-cache
+```
+
+## コンテナ作成・起動（バックグラウンド実行）
+```
+docker compose up -d
+```
+
+## コンテナに入る
+```
+docker compose exec app bash
+```
+
+## コンテナ上でアプリケーション実行（Maven使用する場合）
+```
+docker compose exec app mvn spring-boot:run
+```
+
 ## バージョン確認
 name|version
 --|--

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+services:
+  app:
+    platform: linux/amd64
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./src:/app/src
+    depends_on:
+      - db
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: mydb
+    ports:
+      - "5432:5432"

--- a/pom.xml
+++ b/pom.xml
@@ -1,54 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.3</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.example</groupId>
-	<artifactId>demo</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>demo</name>
-	<description>Demo project for Spring Boot</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>17</java.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.4.3</version>
+    <relativePath/>
+  </parent>
+  <groupId>com.example</groupId>
+  <artifactId>demo</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>demo</name>
+  <description>Demo project for Spring Boot</description>
+  <properties>
+    <java.version>21</java.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/main/java/com/example/demo/HelloController.java
+++ b/src/main/java/com/example/demo/HelloController.java
@@ -8,6 +8,6 @@ public class HelloController {
 
     @GetMapping("/")
     public String hello() {
-        return "Hell, World!";
+        return "Hello, World!";
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,9 @@
-spring.application.name=demo
-server.port=8080
 demoapp.name=Demo App
 demoapp.version=1
+
+spring.application.name=demo
+server.port=8081
+spring.datasource.url=jdbc:postgresql://db:5432/mydb
+spring.datasource.username=user
+spring.datasource.password=password
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
関連ページ
- [開発時のサービス](https://docs.spring.io/spring-boot/reference/features/dev-services.html)
- [Docker Compose サポート](https://docs.spring.io/spring-boot/reference/features/dev-services.html#features.dev-services.docker-compose)

参考記事
- [Docker で Spring Boot](https://spring.pleiades.io/guides/gs/spring-boot-docker)
- [(docker hub) jelastic/maven:3.9.5-openjdk-21](https://hub.docker.com/layers/jelastic/maven/3.9.5-openjdk-21/images/sha256-c43af75dc23700d0687ad4c8773f2ab441af5fb8792c9a18c4de80dfe5eeb9e4)
- [【Mac】占有portの調べ方と空け方](https://zenn.dev/json_hardcoder/articles/5925798786a07a)

その他
- rosettaが8080ポートを占有している可能性から8081ポートを今回使用
以下のエラー発生したため
```
***************************
APPLICATION FAILED TO START
***************************

Description:

Web server failed to start. Port 8081 was already in use.

Action:

Identify and stop the process that's listening on port 8081 or configure this application to listen on another port.
```

- mvn run実行した時にBUILD FAILUREがターミナルに表示されるが、コンパイル後に更新が反映される（原因は調査中）
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.952 s
[INFO] Finished at: 2025-03-06T22:23:09Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.springframework.boot:spring-boot-maven-plugin:3.4.3:run (default-cli) on project demo: Process terminated with exit code: 1 -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```